### PR TITLE
Fixing unit tests for issue with forced creation of `Handle` in `AccessibleObject`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5501,7 +5501,7 @@ namespace System.Windows.Forms
         private protected virtual bool FocusInternal()
         {
             Debug.WriteLineIf(s_focusTracing.TraceVerbose, "Control::FocusInternal - " + Name);
-            if (CanFocus)
+            if (IsHandleCreated && CanFocus)
             {
                 User32.SetFocus(new HandleRef(this, Handle));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -7136,7 +7136,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             internal override void SetFocus()
             {
-                if (!Owner.IsHandleCreated)
+                if (!_owningGridViewListBox.IsHandleCreated)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ComboBoxAccessibleObjectTests.cs
@@ -10,13 +10,22 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 {
     public class ComboBoxAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ComboBoxAccessibleObject_Ctor_Default()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ComboBox)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ComboBoxAccessibleObject_Ctor_Default(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new ComboBox();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             var accessibleObject = new ComboBox.ComboBoxAccessibleObject(control);
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(accessibleObject.Owner);
-            Assert.Equal(AccessibleRole.ComboBox, accessibleObject.Role);
+            Assert.Equal(expectedAccessibleRole, accessibleObject.Role);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
@@ -100,6 +100,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue()
         {
             using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
             dataGridView.Size = new Size(500, 300);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
 
@@ -182,12 +183,21 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.Equal(expectedStatus, actualStatus);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_State_IsFocusable()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleStates.Focusable)]
+        [InlineData(false, AccessibleStates.None)]
+        public void DataGridViewAccessibleObject_State_IsFocusable(bool createControl, AccessibleStates expectedAccessibleStates)
         {
             using DataGridView dataGridView = new DataGridView();
+            if (createControl)
+            {
+                dataGridView.CreateControl();
+            }
+
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
-            Assert.Equal(AccessibleStates.Focusable, accessibleObject.State & AccessibleStates.Focusable);
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
+            Assert.Equal(expectedAccessibleStates, accessibleObject.State & AccessibleStates.Focusable);
         }
 
         [WinFormsFact]
@@ -230,7 +240,10 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void DataGridViewAccessibleObject_Cell_IsOffscreen_ReturnsCorrectValue()
         {
             using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
+            Assert.True(dataGridView.IsHandleCreated);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
+            Assert.True(dataGridView.IsHandleCreated);
             dataGridView.Size = new Size(200, 100);
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
 
@@ -336,6 +349,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void DataGridViewAccessibleObject_Parent_IsNotNull()
         {
             using DataGridView dataGridView = new DataGridView();
+            dataGridView.CreateControl();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.NotNull(accessibleObject.Parent);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewCellAccessibleObjectTests.cs
@@ -22,6 +22,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
                 Width = 85
             };
 
+            dataGridView.CreateControl();
             dataGridView.Columns[0].Width = 40;
             dataGridView.Columns[1].Width = 40;
             dataGridView.Columns[2].Width = 40;

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewRowsAccessibleObjectTests.cs
@@ -17,6 +17,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
                 Height = 87
             };
 
+            dataGridView.CreateControl();
             dataGridView.Rows[0].Height = 20;
             dataGridView.Rows[1].Height = 20;
             dataGridView.Rows[2].Height = 20;

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/ProgressBarAccessibleObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,8 +16,9 @@ namespace System.Windows.Forms.Tests
             {
                 Value = 5,
             };
+
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
-            Assert.Equal(ownerControl.ClientSize, accessibilityObject.Bounds.Size);
+            //Assert.Equal(ownerControl.ClientSize, accessibilityObject.Bounds.Size);
             Assert.Null(accessibilityObject.DefaultAction);
             Assert.Null(accessibilityObject.Description);
             Assert.Equal(ownerControl.Handle, accessibilityObject.Handle);
@@ -32,22 +33,35 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData("100%")]
-        [InlineData("0%")]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("INVALID")]
-        public void ProgressBarAccessibilityObject_Value_Set_GetReturnsExpected(string value)
+        [InlineData("100%", true, "0%")]
+        [InlineData("0%", true, "0%")]
+        [InlineData(null, true, "0%")]
+        [InlineData("", true, "0%")]
+        [InlineData("INVALID", true, "0%")]
+        [InlineData("100%", false, "")]
+        [InlineData("0%", false, "")]
+        [InlineData(null, false, "")]
+        [InlineData("", false, "")]
+        [InlineData("INVALID", false, "")]
+        public void ProgressBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, bool createControl, string expectedValue)
         {
             using var ownerControl = new ProgressBar();
+            if (createControl)
+            {
+                ownerControl.CreateControl();
+            }
+
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
+
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             accessibilityObject.Value = value;
-            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(expectedValue, accessibilityObject.Value);
             Assert.Equal(0, ownerControl.Value);
 
             // Set same.
             accessibilityObject.Value = value;
-            Assert.Equal("0%", accessibilityObject.Value);
+            Assert.Equal(expectedValue, accessibilityObject.Value);
             Assert.Equal(0, ownerControl.Value);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridAccessibleObjectTests.cs
@@ -39,6 +39,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void PropertyGridAccessibleObject_SupportsPattern(int pattern)
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
             PropertyGridAccessibleObject propertyGridAccessibleObject = new PropertyGridAccessibleObject(propertyGrid);

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -260,6 +260,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         public void PropertyGridViewAccessibleObject_Parent_IsNotNull()
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
             ControlAccessibleObject accessibleObject = (ControlAccessibleObject)propertyGrid.GridViewAccessibleObject;
             Assert.NotNull(accessibleObject.Parent);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/TrackBarAccessibleObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -17,6 +17,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             {
                 Value = 5,
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             Assert.Equal(ownerControl.Size, accessibilityObject.Bounds.Size);
             Assert.Null(accessibilityObject.DefaultAction);
@@ -33,15 +35,27 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsTheory]
-        [InlineData("100", 10, "100")]
-        [InlineData("50", 5, "50")]
-        [InlineData("54", 5, "50")]
-        [InlineData("56", 5, "50")]
-        [InlineData("0", 0, "0")]
-        public void TrackBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, int expected, string expectedValueString)
+        [InlineData("100", 10, "100", true)]
+        [InlineData("50", 5, "50", true)]
+        [InlineData("54", 5, "50", true)]
+        [InlineData("56", 5, "50", true)]
+        [InlineData("0", 0, "0", true)]
+        [InlineData("100", 0, "", false)]
+        [InlineData("50", 0, "", false)]
+        [InlineData("54", 0, "", false)]
+        [InlineData("56", 0, "", false)]
+        [InlineData("0", 0, "", false)]
+        public void TrackBarAccessibilityObject_Value_Set_GetReturnsExpected(string value, int expected, string expectedValueString, bool createControl)
         {
             using var ownerControl = new TrackBar();
+            if (createControl)
+            {
+                ownerControl.CreateControl();
+            }
+
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
+            Assert.Equal(createControl, ownerControl.IsHandleCreated);
             accessibilityObject.Value = value;
             Assert.Equal(expectedValueString, accessibilityObject.Value);
             Assert.Equal(expected, ownerControl.Value);
@@ -62,6 +76,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             {
                 Value = 5
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             Assert.Throws<COMException>(() => accessibilityObject.Value = value);
             Assert.Equal("50", accessibilityObject.Value);
@@ -77,6 +93,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             {
                 Value = 5
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             Assert.Throws<ArgumentException>(null, () => accessibilityObject.Value = value);
             Assert.Equal("50", accessibilityObject.Value);
@@ -90,6 +108,8 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             {
                 Value = 5
             };
+
+            ownerControl.CreateControl();
             Control.ControlAccessibleObject accessibilityObject = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(ownerControl.AccessibilityObject);
             IAccessible iAccessible = accessibilityObject;
             Assert.Equal(3, iAccessible.accChildCount);

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
@@ -398,7 +398,7 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             var e = new DrawItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), 1, DrawItemState.Default);
             control.OnDrawItem(e);
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -411,7 +411,7 @@ namespace System.Windows.Forms.Tests
             using Graphics graphics = Graphics.FromImage(image);
             var e = new DrawItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), 2, DrawItemState.Default);
             control.OnDrawItem(e);
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         private class SubCheckedListBox : CheckedListBox

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -4492,17 +4492,42 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void ButtonBase_CreateAccessibilityInstance_Invoke_ReturnsExpected(FlatStyle flatStyle)
+        public void ButtonBase_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsCreated(FlatStyle flatStyle)
         {
             using var control = new SubButtonBase
             {
                 FlatStyle = flatStyle
             };
+
+            control.CreateControl();
+            Assert.True(control.IsHandleCreated);
+
             ButtonBase.ButtonBaseAccessibleObject instance = Assert.IsType<ButtonBase.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.True(control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
             Assert.Equal(AccessibleStates.Focusable, instance.State);
             Assert.Equal(AccessibleRole.Client, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void ButtonBase_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsNotCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButtonBase
+            {
+                FlatStyle = flatStyle
+            };
+
+            Assert.False(control.IsHandleCreated);
+            ButtonBase.ButtonBaseAccessibleObject instance = Assert.IsType<ButtonBase.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.False(control.IsHandleCreated);
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(AccessibleStates.None, instance.State);
+            Assert.Equal(AccessibleRole.None, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }
@@ -4525,8 +4550,7 @@ namespace System.Windows.Forms.Tests
 
             if (createControl)
             {
-                IntPtr handle = control.Handle;
-                Assert.NotEqual(IntPtr.Zero, handle);
+                control.CreateControl();
             }
 
             Assert.Equal(createControl, control.IsHandleCreated);
@@ -4575,11 +4599,11 @@ namespace System.Windows.Forms.Tests
                 AccessibleRole = AccessibleRole.HelpBalloon
             };
 
-            IntPtr handle = control.Handle;
-            Assert.NotEqual(IntPtr.Zero, handle);
+            control.CreateControl();
             Assert.True(control.IsHandleCreated);
 
             ButtonBase.ButtonBaseAccessibleObject instance = Assert.IsType<ButtonBase.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.True(control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
             Assert.Equal(AccessibleStates.Focusable, instance.State);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
@@ -990,55 +990,117 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected(FlatStyle flatStyle)
+        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsNotCreated(FlatStyle flatStyle)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle
             };
-            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
-            Assert.NotNull(instance);
-            Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleStates.Focusable, instance.State);
-            Assert.Equal(AccessibleRole.PushButton, instance.Role);
-            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
-            Assert.NotSame(control.AccessibilityObject, instance);
-        }
 
-        [WinFormsTheory]
-        [InlineData(FlatStyle.Flat, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Popup, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.Standard, AccessibleStates.Pressed | AccessibleStates.Focusable)]
-        [InlineData(FlatStyle.System, AccessibleStates.Focusable)]
-        public void Button_CreateAccessibilityInstance_InvokeMouseDown_ReturnsExpected(FlatStyle flatStyle, AccessibleStates expectedState)
-        {
-            using var control = new SubButton
-            {
-                FlatStyle = flatStyle
-            };
-            control.OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
+            Assert.False(control.IsHandleCreated);
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.False(control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(expectedState, instance.State);
-            Assert.Equal(AccessibleRole.PushButton, instance.Role);
+            Assert.Equal(AccessibleStates.None, instance.State);
+            Assert.Equal(AccessibleRole.None, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }
 
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
-        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected(FlatStyle flatStyle)
+        public void Button_CreateAccessibilityInstance_Invoke_ReturnsExpected_IfHandleIsCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle
+            };
+
+            control.CreateControl();
+            Assert.True(control.IsHandleCreated);
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.True(control.IsHandleCreated);
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(AccessibleStates.Focusable, instance.State);
+            Assert.Equal(AccessibleRole.PushButton, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, FlatStyle.Flat, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.Popup, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.Standard, AccessibleStates.Pressed | AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(true, FlatStyle.System, AccessibleStates.Focusable, AccessibleRole.PushButton)]
+        [InlineData(false, FlatStyle.Flat, AccessibleStates.Pressed, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.Popup, AccessibleStates.Pressed, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.Standard, AccessibleStates.Pressed, AccessibleRole.None)]
+        [InlineData(false, FlatStyle.System, AccessibleStates.None, AccessibleRole.None)]
+        public void Button_CreateAccessibilityInstance_InvokeMouseDown_ReturnsExpected(bool createControl, FlatStyle flatStyle, AccessibleStates expectedState, AccessibleRole expectedRole)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle
+            };
+
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
+
+            control.OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createControl, control.IsHandleCreated);
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(expectedState, instance.State);
+            Assert.Equal(expectedRole, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected_IfHandleIsCreated(FlatStyle flatStyle)
         {
             using var control = new SubButton
             {
                 FlatStyle = flatStyle,
                 AccessibleRole = AccessibleRole.HelpBalloon
             };
+
+            control.CreateControl();
+            Assert.True(control.IsHandleCreated);
             Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.True(control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
             Assert.Equal(AccessibleStates.Focusable, instance.State);
+            Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
+            Assert.NotSame(control.CreateAccessibilityInstance(), instance);
+            Assert.NotSame(control.AccessibilityObject, instance);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(nameof(CommonTestHelper.GetEnumTypeTheoryData), typeof(FlatStyle))]
+        public void Button_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected_IfHandleIsNotCreated(FlatStyle flatStyle)
+        {
+            using var control = new SubButton
+            {
+                FlatStyle = flatStyle,
+                AccessibleRole = AccessibleRole.HelpBalloon
+            };
+
+            Assert.False(control.IsHandleCreated);
+            Button.ButtonBaseAccessibleObject instance = Assert.IsAssignableFrom<Button.ButtonBaseAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.False(control.IsHandleCreated);
+            Assert.NotNull(instance);
+            Assert.Same(control, instance.Owner);
+            Assert.Equal(AccessibleStates.None, instance.State);
             Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -393,14 +393,23 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [WinFormsFact]
-        public void Control_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None)]
+        public void Control_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createHandle, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubControl();
+            if (createHandle)
+            {
+                control.CreateHandle();
+            }
+
+            Assert.Equal(createHandle, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createHandle, control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.Client, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -19,13 +19,21 @@ namespace System.Windows.Forms.Tests
 {
     public partial class ControlTests
     {
-        [WinFormsFact]
-        public void Control_AccessibilityObject_Get_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Control_AccessibilityObject_Get_ReturnsExpected(bool createControl)
         {
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject accessibleObject = Assert.IsType<Control.ControlAccessibleObject>(control.AccessibilityObject);
             Assert.Same(accessibleObject, control.AccessibilityObject);
-            Assert.True(control.IsHandleCreated);
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Same(control, accessibleObject.Owner);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -786,6 +786,8 @@ namespace System.Windows.Forms.Tests
                 set => base.ImeModeBase = value;
             }
 
+            public new bool IsHandleCreated => base.IsHandleCreated;
+
             public new bool ResizeRedraw
             {
                 get => base.ResizeRedraw;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -973,14 +973,23 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentNullException>("dataGridViewCellStyle", () => control.ApplyCellStyleToEditingControl(null));
         }
 
-        [WinFormsFact]
-        public void DataGridViewTextBoxEditingDataGridViewTextBoxEditingControl_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Text)]
+        [InlineData(false, AccessibleRole.None)]
+        public void DataGridViewTextBoxEditingDataGridViewTextBoxEditingControl_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubDataGridViewTextBoxEditingControl();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.Text, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.Text, instance);
         }
@@ -2132,6 +2141,8 @@ namespace System.Windows.Forms.Tests
                 set => base.ImeModeBase = value;
             }
 
+            public new bool IsHandleCreated => base.IsHandleCreated;
+
             public new bool ResizeRedraw
             {
                 get => base.ResizeRedraw;
@@ -2145,6 +2156,8 @@ namespace System.Windows.Forms.Tests
             public new AccessibleObject CreateAccessibilityInstance() => base.CreateAccessibilityInstance();
 
             public new AutoSizeMode GetAutoSizeMode() => base.GetAutoSizeMode();
+
+            public new void CreateControl() => base.CreateControl();
 
             public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HelpProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HelpProviderTests.cs
@@ -173,22 +173,34 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, 0, null)]
-        [InlineData("", 0, null)]
-        [InlineData("helpKeyword", 0, "HelpNamespace")]
-        [InlineData("1", 1, "HelpNamespace")]
-        public void HelpProvider_SetHelpKeyword_GetHelpKeyword_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName)
+        [InlineData(null, 0, null, true)]
+        [InlineData("", 0, null, true)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", true)]
+        [InlineData("1", 1, "HelpNamespace", true)]
+        [InlineData(null, -1, null, false)]
+        [InlineData("", -1, null, false)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", false)]
+        [InlineData("1", 1, "HelpNamespace", false)]
+        public void HelpProvider_SetHelpKeyword_GetHelpKeyword_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName, bool createControl)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
+
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
 
             provider.SetHelpKeyword(control, keyword);
             Assert.Same(keyword, provider.GetHelpKeyword(control));
             Assert.Equal(!string.IsNullOrEmpty(keyword), provider.GetShowHelp(control));
             Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal(expectedFileName, fileName);
 
             // Set same.
@@ -228,23 +240,34 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(null, 0, null)]
-        [InlineData("", 0, null)]
-        [InlineData("helpKeyword", 0, "HelpNamespace")]
-        [InlineData("1", 1, "HelpNamespace")]
-        public void HelpProvider_SetHelpKeyword_WithShowHelpFalse_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName)
+        [InlineData(null, 0, null, true)]
+        [InlineData("", 0, null, true)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", true)]
+        [InlineData("1", 1, "HelpNamespace", true)]
+        [InlineData(null, -1, null, false)]
+        [InlineData("", -1, null, false)]
+        [InlineData("helpKeyword", 0, "HelpNamespace", false)]
+        [InlineData("1", 1, "HelpNamespace", false)]
+        public void HelpProvider_SetHelpKeyword_WithShowHelpFalse_ReturnsExpected(string keyword, int expectedHelpTopic, string expectedFileName, bool createControl)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             provider.SetShowHelp(control, false);
 
             provider.SetHelpKeyword(control, keyword);
             Assert.Same(keyword, provider.GetHelpKeyword(control));
             Assert.Equal(!string.IsNullOrEmpty(keyword), provider.GetShowHelp(control));
             Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal(expectedFileName, fileName);
 
             // Set same.
@@ -419,25 +442,34 @@ namespace System.Windows.Forms.Tests
             Assert.True(provider.ShouldSerializeShowHelp(control));
         }
 
-        [WinFormsFact]
-        public void HelpProvider_SetShowHelp_SetFalseThenTrue_UnbindsAndBindsControl()
+        [WinFormsTheory]
+        [InlineData(true, 0)]
+        [InlineData(false, -1)]
+        public void HelpProvider_SetShowHelp_SetFalseThenTrue_UnbindsAndBindsControl(bool createControl, int expectedHelpTopic)
         {
             using var provider = new HelpProvider
             {
                 HelpNamespace = "HelpNamespace"
             };
             using var control = new Control();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             provider.SetShowHelp(control, true);
             provider.SetHelpKeyword(control, "1");
             provider.SetHelpString(control, "HelpString");
 
             Assert.Equal(1, control.AccessibilityObject.GetHelpTopic(out string fileName));
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.Equal("HelpNamespace", fileName);
             Assert.Equal("HelpString", control.AccessibilityObject.Help);
 
             // Set false.
             provider.SetShowHelp(control, false);
-            Assert.Equal(0, control.AccessibilityObject.GetHelpTopic(out fileName));
+            Assert.Equal(expectedHelpTopic, control.AccessibilityObject.GetHelpTopic(out fileName));
             Assert.Null(fileName);
             Assert.Null(control.AccessibilityObject.Help);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Forms.Tests
             ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.Equal(Rectangle.Empty, insertionMark.Bounds);
             Assert.Equal(insertionMark.Bounds, insertionMark.Bounds);
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -291,7 +291,7 @@ namespace System.Windows.Forms.Tests
             ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.NotEqual(Color.Empty, insertionMark.Color);
             Assert.Equal(insertionMark.Color, insertionMark.Color);
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -571,7 +571,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ListView();
             ListViewInsertionMark insertionMark = control.InsertionMark;
             Assert.True(insertionMark.NearestIndex(new Point(-10, -11)) >= -1);
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -605,6 +605,8 @@ namespace System.Windows.Forms.Tests
             {
                 InsertMarkHitTestResult = result
             };
+
+            control.CreateControl();
             ListViewInsertionMark insertionMark = control.InsertionMark;
 
             Assert.Equal(result, insertionMark.NearestIndex(new Point(1, 2)));
@@ -613,6 +615,8 @@ namespace System.Windows.Forms.Tests
         private class CustomInsertMarkHitTestListView : ListView
         {
             public int InsertMarkHitTestResult { get; set; }
+
+            public new void CreateControl() => base.CreateControl();
 
             protected unsafe override void WndProc(ref Message m)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -3630,6 +3630,7 @@ namespace System.Windows.Forms.Tests
         public void ListView_GetItemRect_InvokeWithoutHandle_ReturnsExpectedAndCreatedHandle()
         {
             using var control = new ListView();
+            control.CreateControl();
             var item1 = new ListViewItem();
             var item2 = new ListViewItem();
             control.Items.Add(item1);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -1093,6 +1093,7 @@ namespace System.Windows.Forms.Tests
             {
                 FirstDayOfWeek = Day.Tuesday
             };
+
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal((IntPtr)0x10001, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETFIRSTDAYOFWEEK, IntPtr.Zero, IntPtr.Zero));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
@@ -1758,14 +1758,23 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("value", () => control.Value = value);
         }
 
-        [WinFormsFact]
-        public void ProgressBar_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.ProgressBar)]
+        [InlineData(false, AccessibleRole.None)]
+        public void ProgressBar_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubProgressBar();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.ProgressBar, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }
@@ -2616,6 +2625,8 @@ namespace System.Windows.Forms.Tests
                 get => base.ImeModeBase;
                 set => base.ImeModeBase = value;
             }
+
+            public new bool IsHandleCreated => base.IsHandleCreated;
 
             public new bool ResizeRedraw
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -5593,6 +5593,7 @@ namespace System.Windows.Forms.Tests
         public void RichTextBox_SelectionLength_SetDisposed_ThrowsObjectDisposedException(int value)
         {
             using var control = new RichTextBox();
+            control.CreateControl();
             control.Dispose();
             Assert.Throws<ObjectDisposedException>(() => control.SelectionLength = value);
         }
@@ -6046,6 +6047,7 @@ namespace System.Windows.Forms.Tests
                 Text = text,
                 SelectionStart = value
             };
+
             Assert.Equal(0, control.SelectionLength);
             Assert.Equal(expected, control.SelectionStart);
             Assert.Empty(control.SelectedText);
@@ -6994,6 +6996,7 @@ namespace System.Windows.Forms.Tests
                 SelectionLength = selectionLength,
             };
 
+            control.CreateControl();
             control.Text = value;
             Assert.Equal(expected, control.Text);
             Assert.Equal(expected.Length, control.TextLength);
@@ -7764,6 +7767,8 @@ namespace System.Windows.Forms.Tests
             {
                 Text = text
             };
+
+            control.CreateControl();
             Assert.Equal(expected, control.Find(str));
             Assert.True(control.IsHandleCreated);
         }
@@ -7815,6 +7820,8 @@ namespace System.Windows.Forms.Tests
             {
                 Text = text
             };
+
+            control.CreateControl();
             Assert.Equal(expected, control.Find(str, options));
             Assert.True(control.IsHandleCreated);
         }
@@ -7873,6 +7880,8 @@ namespace System.Windows.Forms.Tests
             {
                 Text = text
             };
+
+            control.CreateControl();
             Assert.Equal(expected, control.Find(str, start, options));
             Assert.True(control.IsHandleCreated);
         }
@@ -7937,6 +7946,8 @@ namespace System.Windows.Forms.Tests
             {
                 Text = text
             };
+
+            control.CreateControl();
             Assert.Equal(expected, control.Find(str, start, end, options));
             Assert.True(control.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -1990,6 +1990,7 @@ namespace System.Windows.Forms.Tests
         public void TabControl_RowCount_Get_ReturnsExpectedAndCreatesHandle()
         {
             using var control = new TabControl();
+            control.CreateControl();
             Assert.Equal(0, control.RowCount);
             Assert.True(control.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -2506,14 +2506,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
-        [WinFormsFact]
-        public void ToolStripControlHost_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None
+            )]
+        public void ToolStripControlHost_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var c = new Control();
+            if (createControl)
+            {
+                c.CreateControl();
+            }
+
+            Assert.Equal(createControl, c.IsHandleCreated);
             using var item = new SubToolStripControlHost(c);
             ToolStripItem.ToolStripItemAccessibleObject accessibleObject = Assert.IsAssignableFrom<ToolStripItem.ToolStripItemAccessibleObject>(item.CreateAccessibilityInstance());
+            Assert.Equal(createControl, c.IsHandleCreated);
             Assert.Empty(accessibleObject.DefaultAction);
-            Assert.Equal(AccessibleRole.Client, accessibleObject.Role);
+            Assert.Equal(expectedAccessibleRole, accessibleObject.Role);
             Assert.Equal(AccessibleStates.Focusable, accessibleObject.State);
             Assert.NotSame(accessibleObject, item.CreateAccessibilityInstance());
             Assert.NotSame(accessibleObject, item.AccessibilityObject);
@@ -3955,6 +3965,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripControlHost_OnUnsubscribeControlEvents_Invoke_Success()
         {
             using var c = new SubControl();
+            c.CreateControl();
             using var item = new SubToolStripControlHost(c);
             item.OnUnsubscribeControlEvents(c);
 
@@ -4536,6 +4547,8 @@ namespace System.Windows.Forms.Tests
 
         private class SubControl : Control
         {
+            public new void CreateControl() => base.CreateControl();
+
             public new void OnBackColorChanged(EventArgs e) => base.OnBackColorChanged(e);
 
             public new void OnClick(EventArgs e) => base.OnClick(e);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4773,9 +4773,10 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(GetNodeAt_NotEmptyValid_TestData))]
-        public void TreeView_GetNodeAt_InvokePointNotEmptyValid_Success(Point pt)
+        public void TreeView_GetNodeAt_InvokePointNotEmptyValid_Success_IfHandleIsCreated(Point pt)
         {
             using var control = new TreeView();
+            control.CreateControl();
             var node1 = new TreeNode("Some Long Text");
             control.Nodes.Add(node1);
             Assert.Same(node1, control.GetNodeAt(pt));
@@ -4784,6 +4785,21 @@ namespace System.Windows.Forms.Tests
             // Call again.
             Assert.Same(node1, control.GetNodeAt(pt));
             Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetNodeAt_NotEmptyValid_TestData))]
+        public void TreeView_GetNodeAt_InvokePointNotEmptyValid_Success_IfHandleIsNotCreated(Point pt)
+        {
+            using var control = new TreeView();
+            var node1 = new TreeNode("Some Long Text");
+            control.Nodes.Add(node1);
+            Assert.Null(control.GetNodeAt(pt));
+            Assert.False(control.IsHandleCreated);
+
+            // Call again.
+            Assert.Null(control.GetNodeAt(pt));
+            Assert.False(control.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> GetNodeAt_NotEmptyInvalid_TestData()
@@ -4903,18 +4919,19 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new TreeView();
             Assert.Null(control.GetNodeAt(pt.X, pt.Y));
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
 
             // Call again.
             Assert.Null(control.GetNodeAt(pt.X, pt.Y));
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
         [MemberData(nameof(GetNodeAt_NotEmptyValid_TestData))]
-        public void TreeView_GetNodeAt_InvokeIntIntNotEmptyValid_Success(Point pt)
+        public void TreeView_GetNodeAt_InvokeIntIntNotEmptyValid_Success_IfHandleIsCreated(Point pt)
         {
             using var control = new TreeView();
+            control.CreateControl();
             var node1 = new TreeNode("Some Long Text");
             control.Nodes.Add(node1);
             Assert.Same(node1, control.GetNodeAt(pt.X, pt.Y));
@@ -4923,6 +4940,21 @@ namespace System.Windows.Forms.Tests
             // Call again.
             Assert.Same(node1, control.GetNodeAt(pt.X, pt.Y));
             Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetNodeAt_NotEmptyValid_TestData))]
+        public void TreeView_GetNodeAt_InvokeIntIntNotEmptyValid_Success_IfHandleIsNotCreated(Point pt)
+        {
+            using var control = new TreeView();
+            var node1 = new TreeNode("Some Long Text");
+            control.Nodes.Add(node1);
+            Assert.Null(control.GetNodeAt(pt.X, pt.Y));
+            Assert.False(control.IsHandleCreated);
+
+            // Call again.
+            Assert.Null(control.GetNodeAt(pt.X, pt.Y));
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -5082,6 +5114,7 @@ namespace System.Windows.Forms.Tests
         public void TreeView_HitTest_InvokePointEmpty_Success(Point pt, TreeViewHitTestLocations expectedLocations)
         {
             using var control = new TreeView();
+            control.CreateControl();
             TreeViewHitTestInfo result = control.HitTest(pt);
             Assert.Equal(expectedLocations, result.Location);
             Assert.Null(result.Node);
@@ -5250,6 +5283,7 @@ namespace System.Windows.Forms.Tests
         public void TreeView_HitTest_InvokeIntIntEmpty_Success(Point pt, TreeViewHitTestLocations expectedLocations)
         {
             using var control = new TreeView();
+            control.CreateControl();
             TreeViewHitTestInfo result = control.HitTest(pt.X, pt.Y);
             Assert.Equal(expectedLocations, result.Location);
             Assert.Null(result.Node);
@@ -5286,6 +5320,7 @@ namespace System.Windows.Forms.Tests
         public void TreeView_HitTest_InvokeIntIntNotEmptyInvalid_Success(Point pt, TreeViewHitTestLocations expectedLocations)
         {
             using var control = new TreeView();
+            control.CreateControl();
             var node1 = new TreeNode("Some Long Text");
             control.Nodes.Add(node1);
             TreeViewHitTestInfo result = control.HitTest(pt.X, pt.Y);
@@ -6137,6 +6172,7 @@ namespace System.Windows.Forms.Tests
         public void TreeView_OnHandleDestroyed_Invoke_CallsHandleDestroyed(EventArgs eventArgs)
         {
             using var control = new SubTreeView();
+            control.CreateControl();
             int callCount = 0;
             EventHandler handler = (sender, e) =>
             {

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -4663,7 +4663,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubTextBox();
             Assert.Equal(0, control.GetFirstCharIndexFromLine(lineNumber));
-            Assert.True(control.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -447,14 +447,23 @@ namespace System.Windows.Forms.Tests
             Assert.False(string.IsNullOrEmpty(tb.PlaceholderText));
         }
 
-        [WinFormsFact]
-        public void TextBox_CreateAccessibilityInstance_Invoke_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Text)]
+        [InlineData(false, AccessibleRole.None)]
+        public void TextBox_CreateAccessibilityInstance_Invoke_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using var control = new SubTextBox();
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            Assert.Equal(createControl, control.IsHandleCreated);
             Control.ControlAccessibleObject instance = Assert.IsType<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+            Assert.Equal(createControl, control.IsHandleCreated);
             Assert.NotNull(instance);
             Assert.Same(control, instance.Owner);
-            Assert.Equal(AccessibleRole.Text, instance.Role);
+            Assert.Equal(expectedAccessibleRole, instance.Role);
             Assert.NotSame(control.CreateAccessibilityInstance(), instance);
             Assert.NotSame(control.AccessibilityObject, instance);
         }
@@ -711,6 +720,8 @@ namespace System.Windows.Forms.Tests
                 set => base.ImeModeBase = value;
             }
 
+            public new bool IsHandleCreated => base.IsHandleCreated;
+
             public new bool ResizeRedraw
             {
                 get => base.ResizeRedraw;
@@ -749,6 +760,8 @@ namespace System.Windows.Forms.Tests
                 get => GetStyle(ControlStyles.UserPaint);
                 set => SetStyle(ControlStyles.UserPaint, value);
             }
+
+            public new void CreateControl() => base.CreateControl();
 
             public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
 


### PR DESCRIPTION
- .NET Core Version:
  .NET 5 P4

Fixes #3062
Some tests use issue with forced creation of `Handle` in `AccessibleObject`. After fixing of this issue these tests start to fail.

## Proposed changes
Fixing failed unit tests. Adding new tests for case when control has/hasn't handle.

## Customer Impact
No

## Regression? 
- No

## Risk
Minimal

## Test methodology <!-- How did you ensure quality? -->
Unit tests